### PR TITLE
Login issues

### DIFF
--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -27,6 +27,7 @@
 
             <argument type="service" id="Shopware\Core\System\SalesChannel\Context\SalesChannelContextPersister"/>
             <argument type="service" id="Shopware\Core\Checkout\Customer\SalesChannel\AccountService"/>
+            <argument type="service" id="Shopware\Core\Checkout\Customer\SalesChannel\LogoutRoute"/>
 
             <call method="setContainer">
                 <argument type="service" id="service_container"/>

--- a/src/Storefront/Controller/AdminLoginController.php
+++ b/src/Storefront/Controller/AdminLoginController.php
@@ -2,7 +2,9 @@
 
 namespace JblLoginAsCustomer\Storefront\Controller;
 
+use Shopware\Core\Checkout\Customer\SalesChannel\AbstractLogoutRoute;
 use Shopware\Core\Checkout\Customer\SalesChannel\AccountService;
+use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextPersister;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Controller\StorefrontController;
@@ -21,10 +23,12 @@ class AdminLoginController extends StorefrontController
     /**
      * @param SalesChannelContextPersister $salesChannelContextPersister
      * @param AccountService $accountService
+     * @param AbstractLogoutRoute $logoutRoute
      */
     public function __construct(
         protected SalesChannelContextPersister $salesChannelContextPersister,
-        protected AccountService $accountService
+        protected AccountService $accountService,
+        protected AbstractLogoutRoute $logoutRoute
     ) {
     }
 
@@ -44,6 +48,10 @@ class AdminLoginController extends StorefrontController
 
             if(!$data || $data["expired"]) {
                 throw new \Exception("Something went wrong");
+            }
+
+            if ($context->getCustomer() !== null) {
+                $this->logoutRoute->logout($context, new RequestDataBag());
             }
 
             $this->accountService->loginById($data["customerId"], $context);

--- a/src/Storefront/Controller/AdminLoginController.php
+++ b/src/Storefront/Controller/AdminLoginController.php
@@ -61,7 +61,7 @@ class AdminLoginController extends StorefrontController
             $this->addFlash(self::DANGER, $this->trans('error.message-default'));
         }
 
-        return $this->redirectToRoute('frontend.home.page');
+        return $this->redirectToRoute('frontend.account.home.page');
     }
 
 }


### PR DESCRIPTION
This PR fixes two issues related to logging in:

### Issues fixed:

1. **Session cross-contamination**: Previously, if there was already a logged-in session on the frontend, some session-based settings and cart data weren't cleared properly, causing them to "leak" to a new user signing in. Now, the session data resets correctly to avoid any cross-contamination.

2. **Header caching in production mode**: With HTTP caching enabled, the entire storefront output, including headers, was cached. This meant if an admin logged in as a customer, they'd still see headers meant for guests, even though the actual login was successful.

### Additional context:

For issue #2, another solution could be generating a new context and assigning it to the `sw-sales-channel-context` request attribute (similar to how `Shopware\Storefront\Controller\AuthController::login()` works). But this would mean calling internal methods from `SalesChannelContextServiceInterface`. Since even the default Shopware login redirects users to the account dashboard rather than the homepage, the solution implemented here seems appropriate.